### PR TITLE
Add React as dependency in mdx test fixture

### DIFF
--- a/packages/core/integration-tests/test/integration/mdx/package.json
+++ b/packages/core/integration-tests/test/integration/mdx/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/packages/core/integration-tests/test/mdx.js
+++ b/packages/core/integration-tests/test/mdx.js
@@ -10,7 +10,7 @@ const mdConfig = {
   filePath: configPath
 };
 
-describe.skip('markdown/mdx', function() {
+describe('markdown/mdx', function() {
   for (let config of [null /* default config -- testing babel  */, mdConfig]) {
     it('should support bundling MDX', async function() {
       Error.stackTraceLimit = 1000;


### PR DESCRIPTION
The Babel transformer checks to see if there is a react dependency before configuring plugins that strip jsx. Without those plugins, Babel chokes on parsing jsx, which was the error you were seeing in your tests. The fix was to add a package.json to the test fixture that lists React as a dependency. 